### PR TITLE
test-lessons.sh: Test mock-up lesson packaging with Bower

### DIFF
--- a/test-lessons.sh
+++ b/test-lessons.sh
@@ -44,7 +44,7 @@ mkdir git &&
 			"main": "README.md",
 			"ignore": [],
 			"dependencies": {
-				"shell-lesson": "git://localhost/shell#^0.1"
+				"shell-lesson": "git://localhost/shell#0.*"
 			}
 		}
 		EOF

--- a/test-lessons.sh
+++ b/test-lessons.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+rm -rf shell git workshop &&
+
+mkdir shell &&
+(
+	cd shell &&
+	git init &&
+	echo "Here's how you use the posix shell..." > README.md &&
+	git add README.md &&
+	cat <<-EOF > bower.json &&
+		{
+			"name": "shell-lesson",
+			"description": "Introduce folks to basic POSIX-shell usage",
+			"license": "CC BY 3.0 Unported",
+			"homepage": "http://example.invalid/shell",
+			"main": "README.md",
+			"ignore": []
+		}
+		EOF
+	git add bower.json &&
+	git commit -m "Bump to 0.1.0" &&
+	git tag v0.1.0
+	sed -i 's/posix/POSIX/' README.md &&
+	git commit -am "Fix 'posix' -> 'POSIX' capitalization" &&
+	git tag v0.1.1
+	echo 'Also talk about some POSIX utilities (cat, grep, ...).' >> README.md &&
+	git commit -am 'Introduce POSIX utilities (cat, grep, ...)' &&
+	git tag v0.2.0
+) &&
+
+mkdir git &&
+(
+	cd git &&
+	git init &&
+	echo "Here's how you use Git..." > README.md &&
+	git add README.md &&
+	cat <<-EOF > bower.json &&
+		{
+			"name": "git-lesson",
+			"description": "Introduce folks to basic Git usage",
+			"license": "CC BY 3.0 Unported",
+			"homepage": "http://example.invalid/git",
+			"main": "README.md",
+			"ignore": [],
+			"dependencies": {
+				"shell-lesson": "git://localhost/shell#^0.1"
+			}
+		}
+		EOF
+	git add bower.json &&
+	git commit -m "Bump to 0.1.0" &&
+	git tag v0.1.0
+) &&
+
+GIT_DAEMON_PID_FILE=$(mktemp git-daemon-pid.XXXXXX) &&
+git daemon --detach --pid-file="${GIT_DAEMON_PID_FILE}" \
+	--export-all --base-path=. &&
+sleep 1 &&
+GIT_DAEMON_PID=$(cat "${GIT_DAEMON_PID_FILE}")
+
+mkdir workshop &&
+(
+	cd workshop &&
+	bower cache clean &&
+	bower install git://localhost/git &&
+	tree &&
+	bower list
+) &&
+
+kill "${GIT_DAEMON_PID}"


### PR DESCRIPTION
This shell script lets you test Bower-based packaging locally.  Note
that semver has stricter compatibility requirements for ^0.x [1](https://github.com/isaacs/node-semver#ranges):

> ^0.1.3 := >=0.1.3-0 <0.2.0-0 "Compatible with 0.1.3". 0.x.x versions
> are special: the first non-zero component indicates potentially
> breaking changes, meaning the caret operator matches any version
> with the same first non-zero component starting at the specified
> version.

So of 0.1.0, 0.1.1, and 0.2.0, ^0.1 will match all but 0.2.0.  That
means the script currently wraps up with:

```
workshop /tmp/z/workshop
└─┬ git-lesson#0.1.0 extraneous
  └── shell-lesson#0.1.1 (latest is 0.2.0)
```

Next up here is working out a virtual dependency example.  I think we
can get this with Bower's renamed package format [2](http://bower.io/docs/api/#install):

```
<name>=<package>#<version>
```

but I haven't added that to this test script yet.
