### PR TITLE
test-lessons.sh: Slot in a custom, per-workshop shell lesson

### DIFF
--- a/test-lessons.sh
+++ b/test-lessons.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-rm -rf shell git workshop student-workshop &&
+rm -rf shell my-shell git workshop my-workshop student-workshop &&
 
 # stock shell lesson
 mkdir shell &&
@@ -28,6 +28,15 @@ mkdir shell &&
 	echo 'Also talk about some POSIX utilities (cat, grep, ...).' >> README.md &&
 	git commit -am 'Introduce POSIX utilities (cat, grep, ...)' &&
 	git tag v0.2.0
+) &&
+
+# customized shell lesson
+git clone shell my-shell &&
+(
+	cd my-shell &&
+	echo 'Also talk about find' >> README.md &&
+	git commit -am 'Talk about find' &&
+	git tag v0.3.0
 ) &&
 
 # stock Git lesson
@@ -80,6 +89,15 @@ mkdir workshop &&
 	git tag v0.1.0
 ) &&
 
+# custom workshop collection, slotting in our custom shell lesson
+git clone workshop my-workshop &&
+(
+	cd my-workshop &&
+	sed -i 's|^\([[:space:]]*\)\(\"git-lesson".*\)|\1"shell-lesson": "git://localhost/my-shell",\n\1\2|' bower.json &&
+	git commit -am "Swap in my-shell for the shell lesson" &&
+	git tag v0.2.0
+) &&
+
 GIT_DAEMON_PID_FILE=$(mktemp git-daemon-pid.XXXXXX) &&
 git daemon --detach --pid-file="${GIT_DAEMON_PID_FILE}" \
 	--export-all --base-path=. &&
@@ -87,7 +105,7 @@ sleep 1 &&
 GIT_DAEMON_PID=$(cat "${GIT_DAEMON_PID_FILE}")
 
 # Student/instructor checkout for the workshop itself
-git clone git://localhost/workshop student-workshop &&
+git clone git://localhost/my-workshop student-workshop &&
 (
 	cd student-workshop &&
 	bower cache clean &&

--- a/test-lessons.sh
+++ b/test-lessons.sh
@@ -11,12 +11,12 @@ mkdir shell &&
 	git add README.md &&
 	cat <<-EOF > bower.json &&
 		{
-			"name": "shell-lesson",
-			"description": "Introduce folks to basic POSIX-shell usage",
-			"license": "CC BY 3.0 Unported",
-			"homepage": "http://example.invalid/shell",
-			"main": "README.md",
-			"ignore": []
+		  "name": "shell-lesson",
+		  "description": "Introduce folks to basic POSIX-shell usage",
+		  "license": "CC BY 3.0 Unported",
+		  "homepage": "http://example.invalid/shell",
+		  "main": "README.md",
+		  "ignore": []
 		}
 		EOF
 	git add bower.json &&
@@ -39,15 +39,15 @@ mkdir git &&
 	git add README.md &&
 	cat <<-EOF > bower.json &&
 		{
-			"name": "git-lesson",
-			"description": "Introduce folks to basic Git usage",
-			"license": "CC BY 3.0 Unported",
-			"homepage": "http://example.invalid/git",
-			"main": "README.md",
-			"ignore": [],
-			"dependencies": {
-				"shell-lesson": "git://localhost/shell#0.*"
-			}
+		  "name": "git-lesson",
+		  "description": "Introduce folks to basic Git usage",
+		  "license": "CC BY 3.0 Unported",
+		  "homepage": "http://example.invalid/git",
+		  "main": "README.md",
+		  "ignore": [],
+		  "dependencies": {
+		    "shell-lesson": "git://localhost/shell#0.*"
+		  }
 		}
 		EOF
 	git add bower.json &&
@@ -64,15 +64,15 @@ mkdir workshop &&
 	git add README.md &&
 	cat <<-EOF > bower.json &&
 		{
-			"name": "swc-workshop",
-			"description": "One-day introduction to software development",
-			"license": "CC BY 3.0 Unported",
-			"homepage": "http://example.invalid/swc",
-			"main": "README.md",
-			"ignore": [],
-			"dependencies": {
-				"git-lesson": "git://localhost/git#^0.*"
-			}
+		  "name": "swc-workshop",
+		  "description": "One-day introduction to software development",
+		  "license": "CC BY 3.0 Unported",
+		  "homepage": "http://example.invalid/swc",
+		  "main": "README.md",
+		  "ignore": [],
+		  "dependencies": {
+		    "git-lesson": "git://localhost/git#^0.*"
+		  }
 		}
 		EOF
 	git add bower.json &&

--- a/test-lessons.sh
+++ b/test-lessons.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-rm -rf shell git workshop &&
+rm -rf shell git workshop student-workshop &&
 
+# stock shell lesson
 mkdir shell &&
 (
 	cd shell &&
@@ -29,6 +30,7 @@ mkdir shell &&
 	git tag v0.2.0
 ) &&
 
+# stock Git lesson
 mkdir git &&
 (
 	cd git &&
@@ -53,17 +55,43 @@ mkdir git &&
 	git tag v0.1.0
 ) &&
 
+# stock workshop collection
+mkdir workshop &&
+(
+	cd workshop &&
+	git init &&
+	echo "Here's how you write software..." > README.md &&
+	git add README.md &&
+	cat <<-EOF > bower.json &&
+		{
+			"name": "swc-workshop",
+			"description": "One-day introduction to software development",
+			"license": "CC BY 3.0 Unported",
+			"homepage": "http://example.invalid/swc",
+			"main": "README.md",
+			"ignore": [],
+			"dependencies": {
+				"git-lesson": "git://localhost/git#^0.*"
+			}
+		}
+		EOF
+	git add bower.json &&
+	git commit -m "Bump to 0.1.0" &&
+	git tag v0.1.0
+) &&
+
 GIT_DAEMON_PID_FILE=$(mktemp git-daemon-pid.XXXXXX) &&
 git daemon --detach --pid-file="${GIT_DAEMON_PID_FILE}" \
 	--export-all --base-path=. &&
 sleep 1 &&
 GIT_DAEMON_PID=$(cat "${GIT_DAEMON_PID_FILE}")
 
-mkdir workshop &&
+# Student/instructor checkout for the workshop itself
+git clone git://localhost/workshop student-workshop &&
 (
-	cd workshop &&
+	cd student-workshop &&
 	bower cache clean &&
-	bower install git://localhost/git &&
+	bower install &&
 	tree &&
 	bower list
 ) &&


### PR DESCRIPTION
Continuing development after #3.  See the commit messages for details.

With this change, we have examples of both transitive (recursive)
dependencies (swc-workshop → git-lesson → shell-lesson) and effective
virtuals (swapping my-shell in for shell as the shell-lesson
supplier).  I think the only outstanding issue with Bower is multiple
endpoints for `bower search` [1](https://github.com/twitwi/lesson-manager/issues/2#issuecomment-49525190).
