### PR TITLE
test-lessons.sh: Assorted cleanups and a new .bowerrc

### DIFF
--- a/04-howto.md
+++ b/04-howto.md
@@ -3,13 +3,13 @@ layout: simple
 title: How To
 ---
 
-We selected [Bower](http://bower.io/) because:
+We selected [Bower][] because:
 
-1. it store the metadata as JSON,
-2. the dependencies are Git repositories and
+1. it store the metadata as [JSON][],
+2. the dependencies are [Git][] repositories and
 3. it resolve the dependencies pretty well.
 
-Before install Bower you need to install Git and Node and after do it:
+Before install Bower you need to install Git and [Node][].  Then:
 
 ~~~
 # npm install -g bower
@@ -19,9 +19,8 @@ Before install Bower you need to install Git and Node and after do it:
 
 (see also "Getting and building lessons with the work-in-progress script")
 
-We have some examples [here](https://github.com/SoftwareCarpentryLessonManager)
-that you can use to test. For example, to download the lesson about open
-science:
+We have some examples [here][lesson-manager] that you can use to
+test. For example, to download the lesson about open science:
 
 ~~~
 $ bower --config.directory=. install https://github.com/SoftwareCarpentryLessonManager/novice-git-intro.git
@@ -333,3 +332,10 @@ update your git remote repository.
 You might also want to create or reuse a lesson collection (like
 `shell-based-bc` above), but that's another story (an easy one, but
 for later).
+
+
+[Bower]: http://bower.io/
+[JSON]: http://json.org/
+[Git]: http://git-scm.com/
+[Node]: http://nodejs.org/
+[lesson-manager]: https://github.com/SoftwareCarpentryLessonManager

--- a/04-howto.md
+++ b/04-howto.md
@@ -3,7 +3,7 @@ layout: simple
 title: How To
 ---
 
-We selected using [Bower](http://bower.io/) because:
+We selected [Bower](http://bower.io/) because:
 
 1. it store the metadata as JSON,
 2. the dependencies are Git repositories and
@@ -15,9 +15,9 @@ Before install Bower you need to install Git and Node and after do it:
 # npm install -g bower
 ~~~
 
-## Getting a Lesson
+## Getting a lesson
 
-(see also "Getting a building lessons with the work-in-progress script")
+(see also "Getting and building lessons with the work-in-progress script")
 
 We have some examples [here](https://github.com/SoftwareCarpentryLessonManager)
 that you can use to test. For example, to download the lesson about open
@@ -42,8 +42,8 @@ $ ls novice-git-intro
 bower.json  index.md
 ~~~
 
-The example above don't have any dependence. Let test with one lesson that has
-dependencies:
+The example above don't have any dependencies. Let test with a lesson
+that has dependencies:
 
 ~~~
 $ bower --config.directory=. install https://github.com/SoftwareCarpentryLessonManager/shell-based-bc.git
@@ -117,10 +117,10 @@ novice-git-backup/  novice-git-open/      novice-shell-filedir/  shell-based-bc/
 novice-git-intro/   novice-shell-create/  novice-shell-intro/
 ~~~
 
-As you can see, it download the lesson and its dependencies **but** the lesson
-and its dependencies are siblings directories and the dependencies should be
-sons of the lesson. As one workaround you can first clone and then resolve the
-dependencies:
+As you can see, it downloaded the lesson and its dependencies **but**
+the lesson and its dependencies are siblings directories. We want the
+dependencies to be children of the lesson. As one workaround you can
+first clone and then resolve the dependencies:
 
 ~~~
 $ git clone https://github.com/SoftwareCarpentryLessonManager/shell-based-bc.git
@@ -193,28 +193,29 @@ bower.json   gloss.md  novice-git-backup/  novice-git-open/      novice-shell-fi
 contents.md  intro.md  novice-git-intro/   novice-shell-create/  novice-shell-intro/    template/
 ~~~
 
-## Building a Lesson
+## Building a lesson
 
 Still working on that.
 
-## Getting a building lessons with the work-in-progress script
+## Getting and building lessons with the work-in-progress script
 
-There is a script which is a thin layer on top of bower+jekyll and which aims at simplify our/your life.
-You can test it with
+There is a script which is a thin layer on top of Bower+Jekyll and
+which aims at simplify our/your life.  You can test it with
 
-    git clone git@github.com:SoftwareCarpentryLessonManager/lesson-manager.git
-    git clone git@github.com:SoftwareCarpentryLessonManager/shell-based-bc.git
-    cd shell-based-bc/
-    ../lesson-manager/protolearningunit.sh update
-    ../lesson-manager/protolearningunit.sh build
+~~~
+$ git clone git@github.com:SoftwareCarpentryLessonManager/lesson-manager.git
+$ git clone git@github.com:SoftwareCarpentryLessonManager/shell-based-bc.git
+$ cd shell-based-bc/
+$ ../lesson-manager/protolearningunit.sh update
+$ ../lesson-manager/protolearningunit.sh build
+$ firefox _site/
+~~~
 
-    firefox _site/
+## Create a new lesson
 
-## Create a New Lesson
-
-Let say that your have a HTML lesson named `index.html` and you want to make it
-easy available to others import it and reuse. Your first step is create a
-metadata file for your lesson.
+Let say that your have a HTML lesson named `index.html` and you want
+to make it easyily available to others import it and reuse. Your first
+step is create a metadata file for your lesson.
 
 ~~~
 $ ls
@@ -231,7 +232,7 @@ $ bower init
 [?] homepage: http://www.your-web-page.com
 [?] set currently installed components as dependencies? No
 [?] add commonly ignored files to ignore list? No
-[?] would you like to mark this package as private which prevents it from being accidentally published to the re[?] would you like to mark this package as private which prevents it from being accidentally published to the registry? No
+[?] would you like to mark this package as private which prevents it from being accidentally published to the registry? No
 
 {
   name: 'Your Awesome Lesson',
@@ -260,8 +261,8 @@ $ cat bower.json
 }
 ~~~
 
-After create your metadata file you *must* create a git repository for it and
-you *must* add the proper tag (e.g., v0.1.0) to it and upload it some here.
+After create your metadata file you *must* create a Git repository for it and
+you *must* add the proper tag (e.g., v0.1.0) to it and publish it somewhere.
 
 ~~~
 $ ls
@@ -276,16 +277,16 @@ $ git commit -m 'Creating lesson that can be imported'
  create mode 100644 index.html
 $ git tag v0.1.0
 $ git remote add origin https://github.com/username/your-awesome-lesson
-$ git push origin master --tags
+$ git push --tags origin master
 ~~~
 
 Congratulations. Someone can import your lesson following the steps at the
 first section of this page.
 
-## Adding Dependencies to Your Lesson
+## Adding dependencies to your lesson
 
-Supposing that you want to import someones lesson that is already available
-some where you just need to:
+If you want to import someone's lesson that is already published, you
+just need to:
 
 ~~~
 $ cat bower.json
@@ -323,13 +324,12 @@ $ cat bower.json
 }
 $ ls
 bower.json  index.html  novice-git-intro/
-[raniere@pupunha] /tmp/tmp.MxUuUzX5I8/your-awesome-lesson
-%
 ~~~
 
 Pretty easy. After you do that you probably want to change something at your
 `index.html`, add the dependencies to your `.gitignore`, save the changes and
 update your git remote repository.
 
-You might also want to do or reuse a lesson collection (like "shell-based-bc" above),
-but that's another story (an easy one, but for later).
+You might also want to create or reuse a lesson collection (like
+`shell-based-bc` above), but that's another story (an easy one, but
+for later).

--- a/test-lessons.sh
+++ b/test-lessons.sh
@@ -3,21 +3,21 @@
 rm -rf shell my-shell git workshop my-workshop student-workshop &&
 
 info() {
-    #printf '\e[3;32m TEST \e[0;m'
-    echo "#################### INFO ####################"
-    for i in "$@"; do
-        echo "#####   $i"
-    done
-    echo "####################"
-    #printf '\e[0;m'
+	# printf '\e[3;32m TEST \e[0;m'
+	echo "#################### INFO ####################"
+	for i in "$@"; do
+		echo "#####   $i"
+	done
+	echo "####################"
+	#printf '\e[0;m'
 }
 
 if which tree ; then
-    echo Using tree
+	echo Using tree
 else
-    tree() {
-        find -name .git -prune -or -true
-    }
+	tree() {
+		find -name .git -prune -or -true
+	}
 fi
 
 # stock shell lesson
@@ -46,7 +46,7 @@ mkdir shell &&
 	echo 'Also talk about some POSIX utilities (cat, grep, ...).' >> README.md &&
 	git commit -am 'Introduce POSIX utilities (cat, grep, ...)' &&
 	git tag v0.2.0
-        info "We just made a 'shell' repository that holds the shell lesson." "It has versions (tags):" "   $(git tag --list | tr '\n'  ' ')"
+	info "We just made a 'shell' repository that holds the shell lesson." "It has versions (tags):" "   $(git tag --list | tr '\n'  ' ')"
 ) &&
 
 # customized shell lesson
@@ -56,7 +56,7 @@ git clone shell my-shell &&
 	echo 'Also talk about find' >> README.md &&
 	git commit -am 'Talk about find' &&
 	git tag v0.3.0
-        info "We just made a 'my-shell' repository as a fork/clone of 'shell' that holds changes by someone else." "It has an added version:" "   $(git tag --list | tr '\n'  ' ')"
+	info "We just made a 'my-shell' repository as a fork/clone of 'shell' that holds changes by someone else." "It has an added version:" "   $(git tag --list | tr '\n'  ' ')"
 ) &&
 
 # stock Git lesson
@@ -82,7 +82,7 @@ mkdir git &&
 	git add bower.json &&
 	git commit -m "Bump to 0.1.0" &&
 	git tag v0.1.0
-        info "We just made a 'git' repository that holds the git lesson." "It has some version:" "   $(git tag --list | tr '\n'  ' ')"
+	info "We just made a 'git' repository that holds the git lesson." "It has some version:" "   $(git tag --list | tr '\n'  ' ')"
 ) &&
 
 # stock workshop collection
@@ -108,7 +108,7 @@ mkdir workshop &&
 	git add bower.json &&
 	git commit -m "Bump to 0.1.0" &&
 	git tag v0.1.0
-        info "We just made a 'workshop' repository that holds the typical bootcamp collection." "It has some version:" "   $(git tag --list | tr '\n'  ' ')"
+	info "We just made a 'workshop' repository that holds the typical bootcamp collection." "It has some version:" "   $(git tag --list | tr '\n'  ' ')"
 ) &&
 
 # custom workshop collection, slotting in our custom shell lesson
@@ -118,7 +118,7 @@ git clone workshop my-workshop &&
 	sed -i 's|^\([[:space:]]*\)\(\"git-lesson".*\)|\1"shell-lesson": "git://localhost/my-shell",\n\1\2|' bower.json &&
 	git commit -am "Swap in my-shell for the shell lesson" &&
 	git tag v0.2.0
-        info "We just made a 'my-workshop' repository that holds an evolution of the bootcamp collection." "It adds the custom 'my-shell' dependency." "It has some version:" "   $(git tag --list | tr '\n'  ' ')"
+	info "We just made a 'my-workshop' repository that holds an evolution of the bootcamp collection." "It adds the custom 'my-shell' dependency." "It has some version:" "   $(git tag --list | tr '\n'  ' ')"
 ) &&
 
 GIT_DAEMON_PID_FILE=$(mktemp git-daemon-pid.XXXXXX) &&
@@ -135,7 +135,7 @@ git clone git://localhost/my-workshop student-workshop &&
 	bower install &&
 	tree &&
 	bower list
-        info "We just created a repo 'student-workshop' as a clone of 'workshop', simulating the student behavior." "It is just a plain clone + some bower runs.:"
+	info "We just created a repo 'student-workshop' as a clone of 'workshop', simulating the student behavior." "It is just a plain clone + some bower runs.:"
 ) &&
 
 kill "${GIT_DAEMON_PID}"

--- a/test-lessons.sh
+++ b/test-lessons.sh
@@ -12,7 +12,7 @@ info() {
 	#printf '\e[0;m'
 }
 
-if which tree ; then
+if command -v tree ; then
 	echo Using tree
 else
 	tree() {

--- a/test-lessons.sh
+++ b/test-lessons.sh
@@ -80,6 +80,12 @@ mkdir git &&
 		}
 		EOF
 	git add bower.json &&
+	cat <<-EOF > .bowerrc &&
+		{
+		  "directory": "."
+		}
+		EOF
+	git add .bowerrc &&
 	git commit -m "Bump to 0.1.0" &&
 	git tag v0.1.0 &&
 	info "Made a 'git' repository with the Git lesson." \
@@ -107,6 +113,12 @@ mkdir workshop &&
 		}
 		EOF
 	git add bower.json &&
+	cat <<-EOF > .bowerrc &&
+		{
+		  "directory": "."
+		}
+		EOF
+	git add .bowerrc &&
 	git commit -m "Bump to 0.1.0" &&
 	git tag v0.1.0 &&
 	info "Made a 'workshop' repository with a lesson collection." \

--- a/test-lessons.sh
+++ b/test-lessons.sh
@@ -75,7 +75,7 @@ mkdir git &&
 		  "main": "README.md",
 		  "ignore": [],
 		  "dependencies": {
-		    "shell-lesson": "git://localhost/shell#0.*"
+		    "shell": "git://localhost/shell#0.*"
 		  }
 		}
 		EOF
@@ -108,7 +108,7 @@ mkdir workshop &&
 		  "main": "README.md",
 		  "ignore": [],
 		  "dependencies": {
-		    "git-lesson": "git://localhost/git#^0.*"
+		    "git": "git://localhost/git#^0.*"
 		  }
 		}
 		EOF
@@ -129,7 +129,7 @@ mkdir workshop &&
 git clone workshop my-workshop &&
 (
 	cd my-workshop &&
-	sed -i 's|^\([[:space:]]*\)\(\"git-lesson".*\)|\1"shell-lesson": "git://localhost/my-shell",\n\1\2|' bower.json &&
+	sed -i 's|^\([[:space:]]*\)\(\"git".*\)|\1"shell": "git://localhost/my-shell",\n\1\2|' bower.json &&
 	git commit -am "Swap in my-shell for the shell lesson" &&
 	git tag v0.2.0 &&
 	info "Made a 'my-workshop' repository with a fork/clone of 'workshop'" \

--- a/test-lessons.sh
+++ b/test-lessons.sh
@@ -4,11 +4,9 @@ rm -rf shell my-shell git workshop my-workshop student-workshop &&
 
 info() {
 	# printf '\e[3;32m TEST \e[0;m'
-	echo "#################### INFO ####################"
 	for i in "$@"; do
-		echo "#####   $i"
+		echo "## $i"
 	done
-	echo "####################"
 	#printf '\e[0;m'
 }
 

--- a/test-lessons.sh
+++ b/test-lessons.sh
@@ -46,7 +46,8 @@ mkdir shell &&
 	echo 'Also talk about some POSIX utilities (cat, grep, ...).' >> README.md &&
 	git commit -am 'Introduce POSIX utilities (cat, grep, ...)' &&
 	git tag v0.2.0 &&
-	info "We just made a 'shell' repository that holds the shell lesson." "It has versions (tags):" "   $(git tag --list | tr '\n'  ' ')"
+	info "Made a 'shell' repository with the shell lesson." \
+		"Versions (tags): $(git tag --list | tr '\n' ' ')"
 ) &&
 
 # customized shell lesson
@@ -56,7 +57,8 @@ git clone shell my-shell &&
 	echo 'Also talk about find' >> README.md &&
 	git commit -am 'Talk about find' &&
 	git tag v0.3.0 &&
-	info "We just made a 'my-shell' repository as a fork/clone of 'shell' that holds changes by someone else." "It has an added version:" "   $(git tag --list | tr '\n'  ' ')"
+	info "Made a 'my-shell' repository with a fork/clone of 'shell'." \
+		"Versions: $(git tag --list | tr '\n' ' ')"
 ) &&
 
 # stock Git lesson
@@ -82,7 +84,8 @@ mkdir git &&
 	git add bower.json &&
 	git commit -m "Bump to 0.1.0" &&
 	git tag v0.1.0 &&
-	info "We just made a 'git' repository that holds the git lesson." "It has some version:" "   $(git tag --list | tr '\n'  ' ')"
+	info "Made a 'git' repository with the Git lesson." \
+		"Versions: $(git tag --list | tr '\n' ' ')"
 ) &&
 
 # stock workshop collection
@@ -108,7 +111,8 @@ mkdir workshop &&
 	git add bower.json &&
 	git commit -m "Bump to 0.1.0" &&
 	git tag v0.1.0 &&
-	info "We just made a 'workshop' repository that holds the typical bootcamp collection." "It has some version:" "   $(git tag --list | tr '\n'  ' ')"
+	info "Made a 'workshop' repository with a lesson collection." \
+		"Versions: $(git tag --list | tr '\n' ' ')"
 ) &&
 
 # custom workshop collection, slotting in our custom shell lesson
@@ -118,7 +122,8 @@ git clone workshop my-workshop &&
 	sed -i 's|^\([[:space:]]*\)\(\"git-lesson".*\)|\1"shell-lesson": "git://localhost/my-shell",\n\1\2|' bower.json &&
 	git commit -am "Swap in my-shell for the shell lesson" &&
 	git tag v0.2.0 &&
-	info "We just made a 'my-workshop' repository that holds an evolution of the bootcamp collection." "It adds the custom 'my-shell' dependency." "It has some version:" "   $(git tag --list | tr '\n'  ' ')"
+	info "Made a 'my-workshop' repository with a fork/clone of 'workshop'" \
+		"Versions: $(git tag --list | tr '\n' ' ')"
 ) &&
 
 GIT_DAEMON_PID_FILE=$(mktemp git-daemon-pid.XXXXXX) &&
@@ -135,7 +140,8 @@ git clone git://localhost/my-workshop student-workshop &&
 	bower install &&
 	tree &&
 	bower list &&
-	info "We just created a repo 'student-workshop' as a clone of 'workshop', simulating the student behavior." "It is just a plain clone + some bower runs."
+	info "Made a 'student-workshop' repository, simulating student behavior." \
+		"It is just a plain clone + some Bower runs."
 ) &&
 
 kill "${GIT_DAEMON_PID}"

--- a/test-lessons.sh
+++ b/test-lessons.sh
@@ -135,7 +135,7 @@ git clone git://localhost/my-workshop student-workshop &&
 	bower install &&
 	tree &&
 	bower list &&
-	info "We just created a repo 'student-workshop' as a clone of 'workshop', simulating the student behavior." "It is just a plain clone + some bower runs.:"
+	info "We just created a repo 'student-workshop' as a clone of 'workshop', simulating the student behavior." "It is just a plain clone + some bower runs."
 ) &&
 
 kill "${GIT_DAEMON_PID}"

--- a/test-lessons.sh
+++ b/test-lessons.sh
@@ -11,7 +11,7 @@ info() {
 }
 
 if command -v tree ; then
-	echo Using tree
+	echo "Using native tree"
 else
 	tree() {
 		find -name .git -prune -or -true

--- a/test-lessons.sh
+++ b/test-lessons.sh
@@ -45,7 +45,7 @@ mkdir shell &&
 	git tag v0.1.1
 	echo 'Also talk about some POSIX utilities (cat, grep, ...).' >> README.md &&
 	git commit -am 'Introduce POSIX utilities (cat, grep, ...)' &&
-	git tag v0.2.0
+	git tag v0.2.0 &&
 	info "We just made a 'shell' repository that holds the shell lesson." "It has versions (tags):" "   $(git tag --list | tr '\n'  ' ')"
 ) &&
 
@@ -55,7 +55,7 @@ git clone shell my-shell &&
 	cd my-shell &&
 	echo 'Also talk about find' >> README.md &&
 	git commit -am 'Talk about find' &&
-	git tag v0.3.0
+	git tag v0.3.0 &&
 	info "We just made a 'my-shell' repository as a fork/clone of 'shell' that holds changes by someone else." "It has an added version:" "   $(git tag --list | tr '\n'  ' ')"
 ) &&
 
@@ -81,7 +81,7 @@ mkdir git &&
 		EOF
 	git add bower.json &&
 	git commit -m "Bump to 0.1.0" &&
-	git tag v0.1.0
+	git tag v0.1.0 &&
 	info "We just made a 'git' repository that holds the git lesson." "It has some version:" "   $(git tag --list | tr '\n'  ' ')"
 ) &&
 
@@ -107,7 +107,7 @@ mkdir workshop &&
 		EOF
 	git add bower.json &&
 	git commit -m "Bump to 0.1.0" &&
-	git tag v0.1.0
+	git tag v0.1.0 &&
 	info "We just made a 'workshop' repository that holds the typical bootcamp collection." "It has some version:" "   $(git tag --list | tr '\n'  ' ')"
 ) &&
 
@@ -117,7 +117,7 @@ git clone workshop my-workshop &&
 	cd my-workshop &&
 	sed -i 's|^\([[:space:]]*\)\(\"git-lesson".*\)|\1"shell-lesson": "git://localhost/my-shell",\n\1\2|' bower.json &&
 	git commit -am "Swap in my-shell for the shell lesson" &&
-	git tag v0.2.0
+	git tag v0.2.0 &&
 	info "We just made a 'my-workshop' repository that holds an evolution of the bootcamp collection." "It adds the custom 'my-shell' dependency." "It has some version:" "   $(git tag --list | tr '\n'  ' ')"
 ) &&
 
@@ -134,7 +134,7 @@ git clone git://localhost/my-workshop student-workshop &&
 	bower cache clean &&
 	bower install &&
 	tree &&
-	bower list
+	bower list &&
 	info "We just created a repo 'student-workshop' as a clone of 'workshop', simulating the student behavior." "It is just a plain clone + some bower runs.:"
 ) &&
 


### PR DESCRIPTION
For projects with dependencies, a local .bowerrc setting '"directory":
"."' avoids the bower_components namespace.  Otherwise this PR is
mostly cleanup tweaks to the Bash script.
